### PR TITLE
Added a "\" in the list comprehension for the cumplot

### DIFF
--- a/paretochart/paretochart.py
+++ b/paretochart/paretochart.py
@@ -1,6 +1,5 @@
 from operator import itemgetter
 import matplotlib.pyplot as plt
-
 def pareto(data, labels=[], cumplot=True, axes=None, limit=1.0,
            data_args=(), data_kw={}, line_args=(), line_kw={},
            limit_kw={}):
@@ -194,7 +193,7 @@ def pareto(data, labels=[], cumplot=True, axes=None, limit=1.0,
     
     # adjust the second axis if cumplot=True
     if cumplot:
-        yt = [str(int(it))+r'%' for it in ax2.get_yticks()]
+        yt = [str(int(it))+r'\%' for it in ax2.get_yticks()]
         ax2.set_yticklabels(yt)
 
     if cumplot:


### PR DESCRIPTION
The cumplot function causes problems if you use LaTeX for text rendering.
I found that the reason was the "%" character in the list comprehension used to calculate the sum.
A "\" in front of  it did the trick and when I tested it without LaTeX, it worked fine as well.
Awesome little library all in all. Using it for my Bachelor´s thesis (Business chemistry) and will cite this one.
